### PR TITLE
UPLC scripts updated

### DIFF
--- a/benchs/bench-cpu-mem/Main.hs
+++ b/benchs/bench-cpu-mem/Main.hs
@@ -160,12 +160,12 @@ main = do
     saveFlat2 input proof "assets/verifyPlonkScript"  $ verifyPlonkCompiled setup
 
     hPrintf h "\n\n"
-    hPrintf h "Run plonk verify\n\n"
+    hPrintf h "Run \'verifyPlonk\'\n\n"
     printHeader h
     printCostsVerifyPlonk h setup input proof
     hPrintf h "\n\n"
     hPrintf h "\n\n"
-    hPrintf h "Run plonk verifier\n\n"
+    hPrintf h "Run \'plonkVerifier\'\n\n"
     printHeader h
     printCostsPlonkVerifier h setup $ contextPlonk proof
     -- hPrintf h "\n\n"

--- a/src/ZkFold/Cardano/Plonk.hs
+++ b/src/ZkFold/Cardano/Plonk.hs
@@ -181,10 +181,10 @@ instance (KnownNat n, KnownNat (3 * n), KnownNat ((4 * n) + 6)) => CompatibleNon
     nipProofTransform = mkProof
 
 untypedVerifyPlonk :: SetupBytes -> BuiltinData -> BuiltinData -> BuiltinUnit
-untypedVerifyPlonk computation' input proof =
+untypedVerifyPlonk computation input' proof' =
     check
     ( verify @PlonkPlutus
-        computation'
-        (unsafeFromBuiltinData input)
-        (unsafeFromBuiltinData proof)
+        computation
+        (unsafeFromBuiltinData input')
+        (unsafeFromBuiltinData proof')
     )

--- a/src/ZkFold/Cardano/Scripts/ForwardingScripts.hs
+++ b/src/ZkFold/Cardano/Scripts/ForwardingScripts.hs
@@ -34,15 +34,19 @@ forwardingMint _label symbolHash _ ctx =
         -- Finding scripts to be executed
         reds = keys $ txInfoRedeemers $ scriptContextTxInfo ctx
 
-untypedForwardingReward :: BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit
-untypedForwardingReward datum redeemer ctx =
-  check
-    ( forwardingReward
-        (unsafeFromBuiltinData datum)
-        (unsafeFromBuiltinData redeemer)
-        (unsafeFromBuiltinData ctx)
-    )
+{-# INLINABLE untypedForwardingReward #-}
+untypedForwardingReward :: BuiltinData -> BuiltinUnit
+untypedForwardingReward ctx' =
+  let ctx = unsafeFromBuiltinData ctx' in
+    case scriptContextScriptInfo ctx of
+      SpendingScript _ (Just dat) -> check $
+        forwardingReward
+          (unsafeFromBuiltinData . getDatum $ dat)
+          (unsafeFromBuiltinData . getRedeemer . scriptContextRedeemer $ ctx)
+          ctx
+      _                           -> error ()
 
+{-# INLINABLE untypedForwardingMint #-}
 untypedForwardingMint :: FMLabel -> BuiltinData -> BuiltinUnit
 untypedForwardingMint label' ctx' =
   let ctx = unsafeFromBuiltinData ctx' in
@@ -53,4 +57,4 @@ untypedForwardingMint label' ctx' =
           (unsafeFromBuiltinData . getDatum $ dat)
           (unsafeFromBuiltinData . getRedeemer . scriptContextRedeemer $ ctx)
           ctx
-      _                             -> error ()
+      _                           -> error ()

--- a/src/ZkFold/Cardano/Scripts/PlonkVerifier.hs
+++ b/src/ZkFold/Cardano/Scripts/PlonkVerifier.hs
@@ -3,12 +3,12 @@
 module ZkFold.Cardano.Scripts.PlonkVerifier where
 
 import           PlutusLedgerApi.V1.Value                 (Value (..))
-import           PlutusLedgerApi.V3                       (ScriptContext (..), TokenName (..), TxInfo (..))
+import           PlutusLedgerApi.V3                       (ScriptContext (..), TokenName (..), TxInfo (..), getRedeemer)
 import           PlutusLedgerApi.V3.Contexts              (ownCurrencySymbol)
 import           PlutusTx                                 (UnsafeFromData (..))
 import qualified PlutusTx.AssocMap                        as AssocMap
 import           PlutusTx.Prelude                         (Bool (..), BuiltinData, BuiltinUnit, Maybe (..), Ord (..),
-                                                           check, ($), (||))
+                                                           check, ($), (||), (.))
 
 import           ZkFold.Base.Protocol.NonInteractiveProof (NonInteractiveProof (..))
 import           ZkFold.Cardano.Plonk                     (PlonkPlutus)
@@ -39,12 +39,11 @@ plonkVerifier computation proof ctx =
         -- Verifying the Plonk `proof` for the `computation` on `input`
         conditionVerifying = verify @PlonkPlutus computation input proof
 
-untypedPlonkVerifier :: SetupBytes -> BuiltinData -> BuiltinData -> BuiltinUnit
-untypedPlonkVerifier computation' redeemerProof' ctx' =
-    let ctx = unsafeFromBuiltinData ctx'
-        redeemerProof = unsafeFromBuiltinData redeemerProof' in
-    check $
-    plonkVerifier
-        computation'
-        redeemerProof
-        ctx
+{-# INLINABLE untypedPlonkVerifier #-}
+untypedPlonkVerifier :: SetupBytes -> BuiltinData -> BuiltinUnit
+untypedPlonkVerifier computation' ctx' =
+  let
+    ctx           = unsafeFromBuiltinData ctx'
+    redeemerProof = unsafeFromBuiltinData . getRedeemer . scriptContextRedeemer $ ctx
+  in
+    check $ plonkVerifier computation' redeemerProof ctx

--- a/src/ZkFold/Cardano/Scripts/PlonkVerifier.hs
+++ b/src/ZkFold/Cardano/Scripts/PlonkVerifier.hs
@@ -8,7 +8,7 @@ import           PlutusLedgerApi.V3.Contexts              (ownCurrencySymbol)
 import           PlutusTx                                 (UnsafeFromData (..))
 import qualified PlutusTx.AssocMap                        as AssocMap
 import           PlutusTx.Prelude                         (Bool (..), BuiltinData, BuiltinUnit, Maybe (..), Ord (..),
-                                                           check, ($), (||), (.))
+                                                           check, ($), (.), (||))
 
 import           ZkFold.Base.Protocol.NonInteractiveProof (NonInteractiveProof (..))
 import           ZkFold.Cardano.Plonk                     (PlonkPlutus)

--- a/src/ZkFold/Cardano/Scripts/Rollup.hs
+++ b/src/ZkFold/Cardano/Scripts/Rollup.hs
@@ -2,7 +2,7 @@
 
 module ZkFold.Cardano.Scripts.Rollup where
 
-import           GHC.ByteOrder                            (ByteOrder(..))
+import           GHC.ByteOrder                            (ByteOrder (..))
 import           PlutusLedgerApi.V3
 import           PlutusLedgerApi.V3.Contexts              (findOwnInput)
 import           PlutusTx.Prelude                         hiding ((*), (+))
@@ -10,8 +10,8 @@ import           PlutusTx.Prelude                         hiding ((*), (+))
 import           ZkFold.Base.Algebra.Basic.Class          ((*), (+))
 import           ZkFold.Base.Protocol.NonInteractiveProof (NonInteractiveProof (..))
 import           ZkFold.Cardano.Plonk                     (PlonkPlutus)
-import           ZkFold.Cardano.Plonk.OnChain             (F(..))
-import           ZkFold.Cardano.Plonk.OnChain.Data        (ProofBytes, SetupBytes, InputBytes (..))
+import           ZkFold.Cardano.Plonk.OnChain             (F (..))
+import           ZkFold.Cardano.Plonk.OnChain.Data        (InputBytes (..), ProofBytes, SetupBytes)
 import           ZkFold.Cardano.Plonk.OnChain.Utils       (dataToBlake)
 
 -- | Plutus script for verifying a ZkFold Rollup state transition.

--- a/src/ZkFold/Cardano/Scripts/SymbolicVerifier.hs
+++ b/src/ZkFold/Cardano/Scripts/SymbolicVerifier.hs
@@ -1,6 +1,6 @@
 module ZkFold.Cardano.Scripts.SymbolicVerifier where
 
-import           PlutusLedgerApi.V3                       (ScriptContext(..), TxInfo (..), getRedeemer)
+import           PlutusLedgerApi.V3                       (ScriptContext (..), TxInfo (..), getRedeemer)
 import           PlutusTx                                 (unsafeFromBuiltinData)
 import           PlutusTx.Prelude                         (Bool (..), BuiltinData, BuiltinUnit, check, ($), (.))
 

--- a/src/ZkFold/Cardano/Scripts/SymbolicVerifier.hs
+++ b/src/ZkFold/Cardano/Scripts/SymbolicVerifier.hs
@@ -1,6 +1,6 @@
 module ZkFold.Cardano.Scripts.SymbolicVerifier where
 
-import           PlutusLedgerApi.V3                       (ScriptContext (..), TxInfo (..))
+import           PlutusLedgerApi.V3                       (ScriptContext(..), TxInfo (..), getRedeemer)
 import           PlutusTx                                 (unsafeFromBuiltinData)
 import           PlutusTx.Prelude                         (Bool (..), BuiltinData, BuiltinUnit, check, ($), (.))
 
@@ -30,12 +30,11 @@ symbolicVerifier contract proof ctx =
         -- Computing public input from the transaction data
         input = toInput . dataToBlake $ (ins, refs, outs, range)
 
-untypedSymbolicVerifier :: SetupBytes -> BuiltinData -> BuiltinData -> BuiltinUnit
-untypedSymbolicVerifier contract' redeemerProof' ctx' =
-    let ctx = unsafeFromBuiltinData ctx'
-        redeemerProof = unsafeFromBuiltinData redeemerProof' in
-    check $
-    symbolicVerifier
-        contract'
-        redeemerProof
-        ctx
+{-# INLINABLE untypedSymbolicVerifier #-}
+untypedSymbolicVerifier :: SetupBytes -> BuiltinData -> BuiltinUnit
+untypedSymbolicVerifier contract' ctx' =
+    let
+      ctx           = unsafeFromBuiltinData ctx'
+      redeemerProof = unsafeFromBuiltinData . getRedeemer . scriptContextRedeemer $ ctx
+    in
+      check $ symbolicVerifier contract' redeemerProof ctx

--- a/src/ZkFold/Cardano/UPLC.hs
+++ b/src/ZkFold/Cardano/UPLC.hs
@@ -19,12 +19,12 @@ import           ZkFold.Cardano.Scripts.PlonkVerifier     (untypedPlonkVerifier)
 import           ZkFold.Cardano.Scripts.SymbolicVerifier  (untypedSymbolicVerifier)
 
 
-symbolicVerifierCompiled :: SetupBytes -> CompiledCode (BuiltinData -> BuiltinData -> BuiltinUnit)
+symbolicVerifierCompiled :: SetupBytes -> CompiledCode (BuiltinData -> BuiltinUnit)
 symbolicVerifierCompiled contract =
     $$(compile [|| untypedSymbolicVerifier ||])
     `unsafeApplyCode` liftCodeDef contract
 
-plonkVerifierCompiled :: SetupBytes -> CompiledCode (BuiltinData -> BuiltinData -> BuiltinUnit)
+plonkVerifierCompiled :: SetupBytes -> CompiledCode (BuiltinData -> BuiltinUnit)
 plonkVerifierCompiled computation =
     $$(compile [|| untypedPlonkVerifier ||])
     `unsafeApplyCode` liftCodeDef computation
@@ -34,7 +34,7 @@ verifyPlonkCompiled computation =
     $$(compile [|| untypedVerifyPlonk ||])
     `unsafeApplyCode` liftCodeDef computation
 
-forwardingRewardCompiled :: CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> BuiltinUnit)
+forwardingRewardCompiled :: CompiledCode (BuiltinData -> BuiltinUnit)
 forwardingRewardCompiled =
     $$(compile [|| untypedForwardingReward ||])
 


### PR DESCRIPTION
Updated UPLC scripts to be conformant with PlutusV3.
- Type signature of compiled uplc is `BuiltinData -> BuiltinUnit` for all scripts.
- Except for `verifyPlonkCompiled`, which seems to be used for benchmarking only and not meant to be used onchain.

Resolves #23 .