### PR TITLE
Add `policy` command to Asterizm CLI

### DIFF
--- a/e2e-test/asterizm/Asterizm.md
+++ b/e2e-test/asterizm/Asterizm.md
@@ -5,6 +5,7 @@ This documents describes usage of our prototype implementation of the Asterizm p
 CLI commands are provided to
 
 - compute the hash of a message
+- derive client and relayer policy IDs
 - relayer's certification of the message's hash
 - client's sending of outgoing messages to the blockchain
 - client's receiving of incoming messages with relayer verification
@@ -38,16 +39,17 @@ cabal run zkfold-cli:asterizm -- --help
 zkfold-cli:asterizm - Command-line utility to interact with Cardano. Provides
 specific commands to manage the 'Asterizm' protocol.
 
-Usage: asterizm (client | hash | relayer | retrieve-messages)
+Usage: asterizm (client | hash | policy | relayer | retrieve-messages)
 
 Available options:
   -h,--help                Show this help text
 
 Available commands:
-  client                   
-  hash                     
-  relayer                  
-  retrieve-messages        
+  client
+  hash
+  policy
+  relayer
+  retrieve-messages
 ```
 
 We now describe each command.  The eager reader can jump to [section "End-to-end test"](#end-to-end-test) below to see a sample workflow.
@@ -65,6 +67,48 @@ Usage: asterizm hash --message HEX
 
 Available options:
   --message HEX            Hex-encoded Asterizm structured message.
+  -h,--help                Show this help text
+```
+
+### policy client
+
+Derives and displays the client's policy ID. Does not interact with the blockchain.
+
+```shell
+cabal run zkfold-cli:asterizm -- policy client --help
+```
+
+```output
+Usage: asterizm policy client --client-vkey-file FILEPATH
+  [--relayer-vkey-file FILEPATH]
+  (--incoming | --outgoing)
+
+Available options:
+  --client-vkey-file FILEPATH
+                           client's payment verification key file.
+  --relayer-vkey-file FILEPATH
+                           relayer's payment verification key file.
+  --incoming               Incoming cross-chain message (requires relayer
+                           verification).
+  --outgoing               Outgoing cross-chain message (no relayer verification
+                           needed).
+  -h,--help                Show this help text
+```
+
+### policy relayer
+
+Derives and displays a relayer's policy ID. Does not interact with the blockchain.
+
+```shell
+cabal run zkfold-cli:asterizm -- policy relayer --help
+```
+
+```output
+Usage: asterizm policy relayer --relayer-vkey-file FILEPATH
+
+Available options:
+  --relayer-vkey-file FILEPATH
+                           relayer's payment verification key file.
   -h,--help                Show this help text
 ```
 
@@ -201,6 +245,43 @@ asterizm$ ./00-keygen.sh relayer
 ```
 
 This generates verification and signing keys for the client and relayer roles.
+
+### Policy IDs
+
+Derive the client and relayer policy IDs:
+
+```shell
+asterizm$ # Client policy ID for incoming messages
+asterizm$ cabal run zkfold-cli:asterizm -- policy client \
+  --client-vkey-file ./keys/client.vkey \
+  --relayer-vkey-file ./keys/relayer.vkey \
+  --incoming
+```
+
+```output
+<policy-id>
+```
+
+```shell
+asterizm$ # Client policy ID for outgoing messages
+asterizm$ cabal run zkfold-cli:asterizm -- policy client \
+  --client-vkey-file ./keys/client.vkey \
+  --outgoing
+```
+
+```output
+<policy-id>
+```
+
+```shell
+asterizm$ # Relayer policy ID
+asterizm$ cabal run zkfold-cli:asterizm -- policy relayer \
+  --relayer-vkey-file ./keys/relayer.vkey
+```
+
+```output
+<policy-id>
+```
 
 ### Relayer
 

--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Policy.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Policy.hs
@@ -1,0 +1,39 @@
+module ZkFold.Cardano.Asterizm.Transaction.Policy where
+
+import           GeniusYield.Types
+import           Prelude
+
+import           ZkFold.Cardano.Asterizm.Transaction.Retrieve (derivePolicyId)
+import           ZkFold.Cardano.Asterizm.Types                (MessageDirection (..))
+import           ZkFold.Cardano.Asterizm.Utils                (policyFromPlutus)
+import           ZkFold.Cardano.Options.Common                (readPaymentVerificationKey)
+import           ZkFold.Cardano.UPLC.Asterizm                 (asterizmRelayerCompiled)
+
+
+data ClientTransaction = ClientTransaction
+  { clientVKeyFile   :: !FilePath
+  , relayerVKeyFiles :: ![FilePath]
+  , direction        :: !MessageDirection
+  }
+
+data RelayerTransaction = RelayerTransaction
+  { relayerVKeyFile :: !FilePath
+  }
+
+printClientPolicy :: ClientTransaction -> IO ()
+printClientPolicy (ClientTransaction clientVkeyFile relayerVkeyFiles dir) = do
+  clientVkey   <- readPaymentVerificationKey clientVkeyFile
+  relayerVkeys <- mapM readPaymentVerificationKey relayerVkeyFiles
+
+  let clientPolicyId = derivePolicyId clientVkey relayerVkeys dir
+  putStrLn $ trimQuot (show clientPolicyId)
+
+printRelayerPolicy :: RelayerTransaction -> IO ()
+printRelayerPolicy (RelayerTransaction relayerVkeyFile) = do
+  vkey <- readPaymentVerificationKey relayerVkeyFile
+  let policyId = snd . policyFromPlutus . asterizmRelayerCompiled . pubKeyHashToPlutus . pubKeyHash $ vkey
+  putStrLn $ trimQuot (show policyId)
+
+-- | Remove enclosing quotation marks
+trimQuot :: String -> String
+trimQuot = reverse . drop 1 . reverse . drop 1

--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Options/AsterizmCLI.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Options/AsterizmCLI.hs
@@ -8,6 +8,7 @@ import           Prelude
 
 import qualified ZkFold.Cardano.Asterizm.Transaction.Client   as AsterizmClient
 import qualified ZkFold.Cardano.Asterizm.Transaction.Hash     as AsterizmHash
+import qualified ZkFold.Cardano.Asterizm.Transaction.Policy   as AsterizmPolicy
 import qualified ZkFold.Cardano.Asterizm.Transaction.Relayer  as AsterizmRelayer
 import qualified ZkFold.Cardano.Asterizm.Transaction.Retrieve as AsterizmRetrieve
 import           ZkFold.Cardano.CLI.Parsers
@@ -18,6 +19,8 @@ data ClientCommand
     = TransactionAsterizmClientSend AsterizmClient.SendTransaction
     | TransactionAsterizmClientReceive AsterizmClient.ReceiveTransaction
     | TransactionAsterizmHash AsterizmHash.Transaction
+    | TransactionAsterizmPolicyClient AsterizmPolicy.ClientTransaction
+    | TransactionAsterizmPolicyRelayer AsterizmPolicy.RelayerTransaction
     | TransactionAsterizmRelayer AsterizmRelayer.Transaction
     | TransactionAsterizmRetrieve AsterizmRetrieve.Transaction
 
@@ -41,6 +44,7 @@ pCmds = do
     asum $
         [ pTransactionAsterizmClient
         , TransactionAsterizmHash      <$> pTransactionAsterizmHash
+        , pTransactionAsterizmPolicy
         , TransactionAsterizmRelayer   <$> pTransactionAsterizmRelayer
         , TransactionAsterizmRetrieve  <$> pTransactionAsterizmRetrieve
         ]
@@ -94,6 +98,30 @@ pTransactionAsterizmRelayer = do
             <*> pBenefOutAddress
             <*> pMessageHash
 
+-- | Parser for policy subcommands (client/relayer)
+pTransactionAsterizmPolicy :: Parser ClientCommand
+pTransactionAsterizmPolicy = do
+    subParser "policy" $ Opt.info pCmd $ Opt.progDescDoc Nothing
+  where
+    pCmd = asum
+        [ TransactionAsterizmPolicyClient <$> pPolicyClient
+        , TransactionAsterizmPolicyRelayer <$> pPolicyRelayer
+        ]
+
+    pPolicyClient = subParser "client" $ Opt.info pClientCmd $ Opt.progDescDoc Nothing
+      where
+        pClientCmd = do
+            AsterizmPolicy.ClientTransaction
+                <$> pVerificationKeyFile "client"
+                <*> many (pVerificationKeyFile "relayer")
+                <*> pMessageDirection
+
+    pPolicyRelayer = subParser "relayer" $ Opt.info pRelayerCmd $ Opt.progDescDoc Nothing
+      where
+        pRelayerCmd = do
+            AsterizmPolicy.RelayerTransaction
+                <$> pVerificationKeyFile "relayer"
+
 pTransactionAsterizmRetrieve :: Parser AsterizmRetrieve.Transaction
 pTransactionAsterizmRetrieve = do
     subParser "retrieve-messages" $ Opt.info pCmd $ Opt.progDescDoc Nothing
@@ -112,6 +140,8 @@ runClientCommand = \case
     TransactionAsterizmClientSend    cmd -> ExceptT (Right <$> AsterizmClient.clientSend    cmd)
     TransactionAsterizmClientReceive cmd -> ExceptT (Right <$> AsterizmClient.clientReceive cmd)
     TransactionAsterizmHash          cmd -> ExceptT (Right <$> AsterizmHash.computeHash     cmd)
+    TransactionAsterizmPolicyClient  cmd -> ExceptT (Right <$> AsterizmPolicy.printClientPolicy  cmd)
+    TransactionAsterizmPolicyRelayer cmd -> ExceptT (Right <$> AsterizmPolicy.printRelayerPolicy cmd)
     TransactionAsterizmRelayer       cmd -> ExceptT (Right <$> AsterizmRelayer.relayerMint  cmd)
     TransactionAsterizmRetrieve      cmd -> ExceptT (Right <$> AsterizmRetrieve.retrieveMsgs cmd)
 

--- a/zkfold-cli/zkfold-cli.cabal
+++ b/zkfold-cli/zkfold-cli.cabal
@@ -102,6 +102,7 @@ executable asterizm
         ZkFold.Cardano.Asterizm.Utils
         ZkFold.Cardano.Asterizm.Transaction.Client
         ZkFold.Cardano.Asterizm.Transaction.Hash
+        ZkFold.Cardano.Asterizm.Transaction.Policy
         ZkFold.Cardano.Asterizm.Transaction.Relayer
         ZkFold.Cardano.Asterizm.Transaction.Retrieve
         ZkFold.Cardano.Options.Common


### PR DESCRIPTION
## Summary
- Adds a new `policy` command to the Asterizm CLI with two subcommands:
  - `policy client`: derives the client's policy ID (takes client/relayer vkeys and direction)
  - `policy relayer`: derives a relayer's policy ID (takes relayer vkey only)
- Updates `Asterizm.md` documentation with command reference and usage examples

## Test plan
- [x] Verify `cabal run zkfold-cli:asterizm -- policy client --help` shows expected usage
- [x] Verify `cabal run zkfold-cli:asterizm -- policy relayer --help` shows expected usage
- [x] Run `policy client` and `policy relayer` with test keys and confirm correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)