### PR TITLE
Log signed tx CBOR on Asterizm submit failure

### DIFF
--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Client.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Client.hs
@@ -10,7 +10,7 @@ import           GeniusYield.Types
 import           PlutusLedgerApi.V3            as V3
 import           Prelude
 
-import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus)
+import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus, submitTxWithCborOnFailure)
 import           ZkFold.Cardano.Options.Common (readPaymentVerificationKey)
 import           ZkFold.Cardano.UPLC.Asterizm  (asterizmClientCompiled, asterizmRelayerCompiled, asterizmUserCompiled,
                                                 buildCrosschainHash)
@@ -83,10 +83,12 @@ clientSend (SendTransaction cfgFile skeyFile clientVkeyFile trustedAddressBSs se
                                  asUser w1
                                  (buildTxBody skeleton)
 
-    txid <- runGYTxGameMonadIO nid
-                               providers $
-                               asUser w1
-                               (signTxBody txbody >>= submitTx)
+    tx <- runGYTxGameMonadIO nid
+                              providers $
+                              asUser w1
+                              (signTxBody txbody)
+
+    txid <- submitTxWithCborOnFailure nid providers w1 tx
 
     print txid
 
@@ -146,9 +148,11 @@ clientReceive (ReceiveTransaction cfgFile skeyFile clientVkeyFile relayerVkeyFil
                                  asUser w1
                                  (buildTxBody skeleton)
 
-    txid <- runGYTxGameMonadIO nid
-                               providers $
-                               asUser w1
-                               (signTxBody txbody >>= submitTx)
+    tx <- runGYTxGameMonadIO nid
+                              providers $
+                              asUser w1
+                              (signTxBody txbody)
+
+    txid <- submitTxWithCborOnFailure nid providers w1 tx
 
     print txid

--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Relayer.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/Relayer.hs
@@ -8,7 +8,7 @@ import           GeniusYield.Types
 import           PlutusLedgerApi.V3            as V3
 import           Prelude
 
-import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus)
+import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus, submitTxWithCborOnFailure)
 import           ZkFold.Cardano.Options.Common (readPaymentVerificationKey)
 import           ZkFold.Cardano.UPLC.Asterizm  (asterizmRelayerCompiled)
 
@@ -53,9 +53,11 @@ relayerMint (Transaction cfgFile skeyFile relayerVkeyFile sendTo msgHash) = do
                                  asUser w1
                                  (buildTxBody skeleton)
 
-    txid <- runGYTxGameMonadIO nid
-                               providers $
-                               asUser w1
-                               (signTxBody txbody >>= submitTx)
+    tx <- runGYTxGameMonadIO nid
+                              providers $
+                              asUser w1
+                              (signTxBody txbody)
+
+    txid <- submitTxWithCborOnFailure nid providers w1 tx
 
     print txid

--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/User.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Transaction/User.hs
@@ -8,7 +8,7 @@ import           GeniusYield.Types
 import           PlutusLedgerApi.V3            as V3
 import           Prelude
 
-import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus)
+import           ZkFold.Cardano.Asterizm.Utils (policyFromPlutus, submitTxWithCborOnFailure)
 import           ZkFold.Cardano.UPLC.Asterizm  (asterizmUserCompiled, buildCrosschainHash)
 
 
@@ -55,9 +55,11 @@ userSend (SendTransaction cfgFile skeyFile sendTo msg) = do
                                  asUser w1
                                  (buildTxBody skeleton)
 
-    txid <- runGYTxGameMonadIO nid
+    tx <- runGYTxGameMonadIO nid
                                providers $
                                asUser w1
-                               (signTxBody txbody >>= submitTx)
+                               (signTxBody txbody)
+
+    txid <- submitTxWithCborOnFailure nid providers w1 tx
 
     print txid

--- a/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Utils.hs
+++ b/zkfold-cli/app/asterizm/ZkFold/Cardano/Asterizm/Utils.hs
@@ -1,12 +1,15 @@
 module ZkFold.Cardano.Asterizm.Utils where
 
+import           Control.Exception      (SomeException, catch, throwIO)
 import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as TE
+import           GeniusYield.TxBuilder
 import           GeniusYield.Types
 import           PlutusTx               (CompiledCode)
 import           Prelude
+import           System.IO              (hPutStrLn, stderr)
 
 -- | Minting policy and policy ID from Plutus policy.
 policyFromPlutus :: forall a. CompiledCode a -> (GYBuildScript PlutusV3, GYMintingPolicyId)
@@ -25,3 +28,15 @@ hexToBS :: MonadFail m => T.Text -> m BS.ByteString
 hexToBS t = case B16.decode (TE.encodeUtf8 t) of
   Left err -> fail $ "Invalid hex: " ++ err
   Right bs -> pure bs
+
+-- | Submit a signed transaction and print the CBOR hex when submission fails.
+submitTxWithCborOnFailure :: GYNetworkId -> GYProviders -> User -> GYTx -> IO GYTxId
+submitTxWithCborOnFailure nid providers user tx =
+  runGYTxGameMonadIO nid providers (asUser user (submitTx tx)) `catch` printCborAndRethrow
+  where
+    printCborAndRethrow :: SomeException -> IO GYTxId
+    printCborAndRethrow err = do
+      hPutStrLn stderr "BEGIN_SIGNED_TX_CBOR"
+      hPutStrLn stderr (txToHex tx)
+      hPutStrLn stderr "END_SIGNED_TX_CBOR"
+      throwIO err


### PR DESCRIPTION
## Summary
- sign Asterizm transactions before submit so the signed transaction is available for diagnostics
- print signed transaction CBOR hex to stderr when submitTx throws
- preserve the original submit exception after logging the CBOR

## Verification
- cabal -v0 build exe:asterizm --with-compiler=ghc-9.6.7
- dist-newstyle/build/x86_64-linux/ghc-9.6.7/zkfold-cli-0.1.0.0/x/asterizm/build/asterizm/asterizm policy user